### PR TITLE
Assign this to window

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var requestFrame = (function () {
+  var window = this
   var raf = window.requestAnimationFrame ||
     window.mozRequestAnimationFrame ||
     window.webkitRequestAnimationFrame ||
@@ -11,6 +12,7 @@ var requestFrame = (function () {
 })()
 
 var cancelFrame = (function () {
+  var window = this
   var cancel = window.cancelAnimationFrame ||
     window.mozCancelAnimationFrame ||
     window.webkitCancelAnimationFrame ||


### PR DESCRIPTION
Fixes #17

In #14 the `requestFrame` and `cancelFrame` functions were moved into the global scope, so `window` is now undefined when requiring in node. Previously they were created in the `export` function which uses a reference to `this` as `window`, so this wasn't a problem.